### PR TITLE
Development by Environment 

### DIFF
--- a/.github/workflows/cd-dev-1.yml
+++ b/.github/workflows/cd-dev-1.yml
@@ -1,0 +1,16 @@
+name: CD-dev-1
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: deploy dev
+        run: echo "deploy dev"
+

--- a/.github/workflows/cd-dev-2.yml
+++ b/.github/workflows/cd-dev-2.yml
@@ -1,0 +1,16 @@
+name: CD-dev-2
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [closed]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: deploy dev
+        run: echo "deploy dev"
+

--- a/.github/workflows/cd-dev-3.yml
+++ b/.github/workflows/cd-dev-3.yml
@@ -1,0 +1,16 @@
+name: CD-dev-3
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: >-
+      contains(fromJson('["opened", "synchronize", "reopened"]'), github.event.action) ||
+      (github.event.action == 'closed' &&  github.event.pull_request.merged == true && github.ref_name == 'master')
+    steps:
+      - name: deploy dev
+        run: echo "deploy dev"
+

--- a/.github/workflows/cd-prd.yml
+++ b/.github/workflows/cd-prd.yml
@@ -1,0 +1,17 @@
+name: CD-prd
+
+on:
+  push:
+    tags:
+      - 'release-*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: prd
+    if: github.event.base_ref == 'refs/heads/master'
+    steps:
+      - name: deploy prd
+        run: echo "deploy prd"
+

--- a/.github/workflows/cd-stg-1.yml
+++ b/.github/workflows/cd-stg-1.yml
@@ -1,0 +1,15 @@
+name: CD-stg-1
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: stg
+    steps:
+      - name: deploy stg
+        run: echo "deploy stg"
+

--- a/.github/workflows/cd-stg-2.yml
+++ b/.github/workflows/cd-stg-2.yml
@@ -1,0 +1,16 @@
+name: CD-stg-2
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [closed]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: deploy stg
+        run: echo "deploy stg"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: build
+        run: echo "build"
+      - name: test
+        run: echo "test"
+

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,0 +1,22 @@
+# Refs. https://docs.github.com/en/actions/learn-github-actions/contexts#example-printing-context-information-to-the-log
+name: Context testing
+on: push
+
+jobs:
+  dump_contexts_to_log:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump github context
+        id: github_context_step
+        run: echo '${{ toJSON(github) }}'
+      - name: Dump job context
+        run: echo '${{ toJSON(job) }}'
+      - name: Dump steps context
+        run: echo '${{ toJSON(steps) }}'
+      - name: Dump runner context
+        run: echo '${{ toJSON(runner) }}'
+      - name: Dump strategy context
+        run: echo '${{ toJSON(strategy) }}'
+      - name: Dump matrix context
+        run: echo '${{ toJSON(matrix) }}'
+


### PR DESCRIPTION
## 要件
※ この PR を マージし、master をベースに、release-xxx という名称でタグを切り、push すると下記の全ての動作を確認できる。


### push 時に CI(build, test)
- ci.yml


### PR 作成時に dev に CD(deploy)
- cd-dev-1.yml
  - PR 作成時と、その PR の branch に push するたびに動く。
- cd-dev-3.yml
  - cd-dev-1 同様の動作。cd-dev-1, cd-dev-2 の動作を if で表現している。


### PR 作成時に stg に CD(deploy) ※ Manual Approve
- cd-stg-1.yml
  - environment で Manual Approve


### PR マージ時に dev, stg に CD
- cd-dev-1.yml
  - ただし、マージ以外の close でも動いてしまう。
- cd-dev-2.yml
  - PR がマージされた場合のみ動く（close だけでは動かない）。
- cd-dev-3.yml
  - cd-dev-2 と同様の動作。cd-dev-1, cd-dev-2 の動作を if で表現している。
  - => 条件が複雑になるため（可読性が落ちる、テストがしずらい）、cd-dev-1 で妥協するか、PR 作成と PR を master にマージ（cd-dev-2）でファイルを分けるほうがシンプル。
- cd-stg-2.yml
  - cd-dev-2.yml と同様の動作。


### リリースタグを切られると、prd を Manual Approve 後 CD
- cd-prd.yml
  - master ブランチで、release-タグが push されたときに動く。



## Debug
- debug.yml
  - push 毎にコンテキストを出力する。
- [Contexts - GitHub Docs](https://docs.github.com/en/actions/learn-github-actions/contexts#example-printing-context-information-to-the-log)



## if
- [Contexts - GitHub Docs](https://docs.github.com/en/actions/learn-github-actions/contexts#functions)
- [GitHub Actions の if, 否定演算子, そして YAML - pione30’s blog](https://pione30.hatenablog.com/entry/2021/02/05/015545)
- [Only run job on specific branch with GitHub Actions - Stack Overflow](https://stackoverflow.com/questions/58139406/only-run-job-on-specific-branch-with-github-actions/62419599#62419599)



## Environment
Manual Approve するためには、

- Settings/Environment を設定し、
    - `https://github.com/<USER>/<REPOSITORY>/settings/environments`
- コード上にもそれに対応する `environment: name: <NAME>` を設定する
- 設定した Protection Rule に基づいて動作する
    - 指定したレビュアーが Approve することで動作
    - タイマーで動作
    - 対象は、全てのブランチ、指定したブランチ
    - Secret を登録できる


### stg
- Name: stg
- Required reviewers: 自分を設定
- Deployment branches: All branches


### prd
- Name: prd
- Required reviewers: 自分を設定
- Deployment branches: All branches


### Environments の動作まとめ
- コードにのみ、environment が設定されている場合、そのまま動く（何も設定されていない時と同じ動作をする）。
- Environment が名前だけ定義されており、protection rule が未設定の場合、そのまま動く。
- Required reviewers: 最大6名までレビュアーを追加できる。
- PR or Actions には、Waiting と表示される。
    - Review deployments をクリックし、該当する env をチェックし、Approve and deploy をクリックすればデプロイできる。
    - reject を押せば却下でき、アクションは失敗する。
    - リランした場合は、再び同じ動作となり、承認待ちになる。
    - キャンセルもできる。
- Wait timer は、設定分待ってから動作する。
- Deployment branches
    - All branches: すべてのブランチで動作する。
    - Protected branches: Branch protection rules で設定したパターンに合致すると動作する。一致しない場合、失敗する。
    - Selected branches: 設定したパターンに合致すると動作する。一致しない場合、失敗する。
        - 例）master ブランチでリリースタグを切り、push したら動作させたい場合、ここに master を設定してはいけない。
        - その時、branch 名は、master ではなく、リリースタグとなるため条件に一致せず動作しない。以下のエラーになる。
        - `Branch "release-20220619" is not allowed to deploy to prd due to environment protection rules.`
        - それを表現したい場合は、All branch 許可にした上で、`if: github.event.base_ref == 'refs/heads/master'` とする。 Refs. cd-prd.yml
- Environment secrets
    - Action で使える Secret を設定するだけなので、Action の動作 とは関係ない。



## 検証準備
### master ブランチ作成
```
% git switch main
% git switch -c master
% git push origin master
```


### リリースタグ作成
※push した直後に、CD-prd が動作し、Manual Approve 待ち状態になる。

```
% git switch master
% git pull origin master
% git tag release-20220619
% git push origin release-20220619
```


### PR マージ後の master をマージ前の状態に戻す
- PR を Revert してマージする（revert ブランチは不要なので削除する）。
- ローカルで、以下を実施する。

```
% git switch master
% git pull origin master
# first commit 以外のコミットは、全て削除する（d フラグ）。
% git rebase -i $(gci-rebase)
% git push --force-with-lease origin master
```



## Tips
- `run: echo '${{ toJSON(github) }}'` は、コミットメッセージによって失敗する場合がある
    - コミットメッセージに、`()` が含まれていると失敗していそう（詳細未確認）。
- Refs. https://github.com/onigomex/example-github-actions/actions/runs/2523385031
